### PR TITLE
Backend/groups attractions

### DIFF
--- a/backend/src/main/java/share/fare/backend/config/DataInitializer.java
+++ b/backend/src/main/java/share/fare/backend/config/DataInitializer.java
@@ -11,6 +11,7 @@ import share.fare.backend.entity.User;
 import share.fare.backend.repository.UserRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Component
@@ -27,21 +28,21 @@ public class DataInitializer implements ApplicationListener<ContextRefreshedEven
                     .email("user@example.com")
                     .password(passwordEncoder.encode("password"))
                     .role(Role.ADMIN)
-                    .createdAt(LocalDate.now())
+                    .createdAt(LocalDateTime.now())
                     .build();
 
             User user2 = User.builder()
                     .email("user2@example.com")
                     .password(passwordEncoder.encode("password2"))
                     .role(Role.USER)
-                    .createdAt(LocalDate.now())
+                    .createdAt(LocalDateTime.now())
                     .build();
 
             User user3 = User.builder()
                     .email("user3@example.com")
                     .password(passwordEncoder.encode("password3"))
                     .role(Role.USER)
-                    .createdAt(LocalDate.now())
+                    .createdAt(LocalDateTime.now())
                     .build();
 
             userRepository.saveAll(List.of(user1, user2, user3));

--- a/backend/src/main/java/share/fare/backend/controller/ActivityController.java
+++ b/backend/src/main/java/share/fare/backend/controller/ActivityController.java
@@ -2,6 +2,10 @@ package share.fare.backend.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,6 +14,7 @@ import share.fare.backend.dto.request.ActivityRequest;
 import share.fare.backend.dto.response.ActivityResponse;
 import share.fare.backend.entity.User;
 import share.fare.backend.service.ActivityService;
+import share.fare.backend.util.PaginatedResponse;
 
 @RestController
 @RequestMapping("/api/v1/groups/{groupId}/activities")
@@ -24,5 +29,30 @@ public class ActivityController {
             @AuthenticationPrincipal User user) {
         ActivityResponse response = activityService.createActivity(request, user.getId(), groupId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{activityId}")
+    public ResponseEntity<ActivityResponse> updateActivity(
+            @PathVariable Long groupId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody ActivityRequest request) {
+        ActivityResponse response = activityService.updateActivity(request, activityId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{activityId}")
+    public ResponseEntity<Void> deleteActivity(
+            @PathVariable Long groupId,
+            @PathVariable Long activityId) {
+        activityService.deleteActivity(activityId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<PaginatedResponse<ActivityResponse>> getActivitiesForGroup(
+            @PathVariable Long groupId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<ActivityResponse> activities = activityService.getActivitiesForGroup(groupId, pageable);
+        return ResponseEntity.ok(new PaginatedResponse<>(activities));
     }
 }

--- a/backend/src/main/java/share/fare/backend/controller/ActivityController.java
+++ b/backend/src/main/java/share/fare/backend/controller/ActivityController.java
@@ -1,0 +1,28 @@
+package share.fare.backend.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import share.fare.backend.dto.request.ActivityRequest;
+import share.fare.backend.dto.response.ActivityResponse;
+import share.fare.backend.entity.User;
+import share.fare.backend.service.ActivityService;
+
+@RestController
+@RequestMapping("/api/v1/groups/{groupId}/activities")
+@RequiredArgsConstructor
+public class ActivityController {
+    private final ActivityService activityService;
+
+    @PostMapping
+    public ResponseEntity<ActivityResponse> createActivity(
+            @PathVariable Long groupId,
+            @Valid @RequestBody ActivityRequest request,
+            @AuthenticationPrincipal User user) {
+        ActivityResponse response = activityService.createActivity(request, user.getId(), groupId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/controller/VoteController.java
+++ b/backend/src/main/java/share/fare/backend/controller/VoteController.java
@@ -1,0 +1,60 @@
+package share.fare.backend.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import share.fare.backend.dto.request.VoteRequest;
+import share.fare.backend.dto.response.VoteResponse;
+import share.fare.backend.entity.User;
+import share.fare.backend.service.VoteService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/groups/{groupId}/activities/{activityId}/votes")
+@RequiredArgsConstructor
+public class VoteController {
+    private final VoteService voteService;
+
+    @PostMapping
+    public ResponseEntity<VoteResponse> addVote(
+            @PathVariable Long groupId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody VoteRequest request,
+            @AuthenticationPrincipal User user) {
+        VoteResponse response = voteService.addVote(activityId, user.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<VoteResponse>> getVotesForActivity(
+            @PathVariable Long groupId,
+            @PathVariable Long activityId) {
+        List<VoteResponse> votes = voteService.getVotesForActivity(activityId);
+        return ResponseEntity.ok(votes);
+    }
+
+    @PutMapping("/{voteId}")
+    public ResponseEntity<VoteResponse> updateVote(
+            @PathVariable Long groupId,
+            @PathVariable Long activityId,
+            @PathVariable Long voteId,
+            @Valid @RequestBody VoteRequest request,
+            @AuthenticationPrincipal User user) {
+        VoteResponse response = voteService.updateVote(voteId, user.getId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{voteId}")
+    public ResponseEntity<Void> deleteVote(
+            @PathVariable Long groupId,
+            @PathVariable Long activityId,
+            @PathVariable Long voteId,
+            @AuthenticationPrincipal User user) {
+        voteService.deleteVote(voteId, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/share/fare/backend/dto/request/ActivityRequest.java
+++ b/backend/src/main/java/share/fare/backend/dto/request/ActivityRequest.java
@@ -1,0 +1,21 @@
+package share.fare.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.hibernate.validator.constraints.URL;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ActivityRequest {
+    @NotBlank(message = "Activity name is required")
+    private String name;
+
+    private String description;
+    private String location;
+
+    @URL(message = "Link must be a valid URL")
+    private String link;
+}

--- a/backend/src/main/java/share/fare/backend/dto/request/VoteRequest.java
+++ b/backend/src/main/java/share/fare/backend/dto/request/VoteRequest.java
@@ -1,0 +1,15 @@
+package share.fare.backend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import share.fare.backend.entity.VoteType;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VoteRequest {
+    @NotNull(message = "Vote type is required")
+    private VoteType voteType;
+}

--- a/backend/src/main/java/share/fare/backend/dto/response/ActivityResponse.java
+++ b/backend/src/main/java/share/fare/backend/dto/response/ActivityResponse.java
@@ -1,0 +1,22 @@
+package share.fare.backend.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ActivityResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private String location;
+    private String link;
+    private Long groupId;
+    private LocalDateTime createdAt;
+    private List<VoteResponse> votes; // List of votes for this activity
+}

--- a/backend/src/main/java/share/fare/backend/dto/response/ActivityResponse.java
+++ b/backend/src/main/java/share/fare/backend/dto/response/ActivityResponse.java
@@ -18,5 +18,5 @@ public class ActivityResponse {
     private String link;
     private Long groupId;
     private LocalDateTime createdAt;
-    private List<VoteResponse> votes; // List of votes for this activity
+    private List<VoteResponse> votes;
 }

--- a/backend/src/main/java/share/fare/backend/dto/response/GroupResponse.java
+++ b/backend/src/main/java/share/fare/backend/dto/response/GroupResponse.java
@@ -23,4 +23,5 @@ public class GroupResponse {
     private String groupImageUrl;
     private List<String> links;
     private List<GroupMembershipResponse> memberships;
+    private List<ActivityResponse> activities;
 }

--- a/backend/src/main/java/share/fare/backend/dto/response/UserResponse.java
+++ b/backend/src/main/java/share/fare/backend/dto/response/UserResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -13,7 +14,7 @@ import java.util.List;
 public class UserResponse {
     private Long id;
     private String email;
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
     private UserInfoResponse userInfo;
     private List<GroupResponse> groupsCreated;
     private List<GroupMembershipResponse> memberships;

--- a/backend/src/main/java/share/fare/backend/dto/response/VoteResponse.java
+++ b/backend/src/main/java/share/fare/backend/dto/response/VoteResponse.java
@@ -1,0 +1,20 @@
+package share.fare.backend.dto.response;
+
+import lombok.*;
+import share.fare.backend.entity.VoteType;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VoteResponse {
+    private Long id;
+    private Long userId;
+    private String userEmail;
+    private Long activityId;
+    private VoteType voteType;
+    private LocalDateTime votedAt;
+}

--- a/backend/src/main/java/share/fare/backend/entity/Activity.java
+++ b/backend/src/main/java/share/fare/backend/entity/Activity.java
@@ -1,0 +1,42 @@
+package share.fare.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.validator.constraints.URL;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity(name = "group_activity")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Activity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String description;
+    private String location;
+
+    @URL
+    private String link;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Vote> votes = new ArrayList<>();
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/share/fare/backend/entity/Activity.java
+++ b/backend/src/main/java/share/fare/backend/entity/Activity.java
@@ -2,9 +2,9 @@ package share.fare.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.validator.constraints.URL;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,12 +13,8 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class Activity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@SuperBuilder
+public class Activity extends BaseEntity {
     private String name;
     private String description;
     private String location;
@@ -32,11 +28,4 @@ public class Activity {
 
     @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Vote> votes = new ArrayList<>();
-
-    private LocalDateTime createdAt;
-
-    @PrePersist
-    public void prePersist() {
-        createdAt = LocalDateTime.now();
-    }
 }

--- a/backend/src/main/java/share/fare/backend/entity/BaseEntity.java
+++ b/backend/src/main/java/share/fare/backend/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package share.fare.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/share/fare/backend/entity/Group.java
+++ b/backend/src/main/java/share/fare/backend/entity/Group.java
@@ -2,10 +2,9 @@ package share.fare.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.validator.constraints.URL;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,12 +13,8 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class Group {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@SuperBuilder
+public class Group extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
@@ -28,8 +23,6 @@ public class Group {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by", nullable = false)
     private User createdBy;
-
-    private LocalDateTime createdAt;
 
     private LocalDate tripStartDate;
     private LocalDate tripEndDate;
@@ -51,11 +44,6 @@ public class Group {
 
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Activity> activities = new ArrayList<>();
-
-    @PrePersist
-    public void prePersist() {
-        createdAt = LocalDateTime.now();
-    }
 
     public void addMember(User user, GroupRole role) {
         GroupMembership membership = GroupMembership.builder()

--- a/backend/src/main/java/share/fare/backend/entity/Group.java
+++ b/backend/src/main/java/share/fare/backend/entity/Group.java
@@ -49,6 +49,9 @@ public class Group {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupMembership> memberships = new ArrayList<>();
 
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Activity> activities = new ArrayList<>();
+
     @PrePersist
     public void prePersist() {
         createdAt = LocalDateTime.now();

--- a/backend/src/main/java/share/fare/backend/entity/GroupMembership.java
+++ b/backend/src/main/java/share/fare/backend/entity/GroupMembership.java
@@ -2,6 +2,7 @@ package share.fare.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
 
@@ -10,12 +11,8 @@ import java.time.LocalDate;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class GroupMembership {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@SuperBuilder
+public class GroupMembership extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -28,9 +25,4 @@ public class GroupMembership {
     private GroupRole role;
 
     private LocalDate joinedAt;
-
-    @PrePersist
-    public void prePersist() {
-        joinedAt = LocalDate.now();
-    }
 }

--- a/backend/src/main/java/share/fare/backend/entity/User.java
+++ b/backend/src/main/java/share/fare/backend/entity/User.java
@@ -2,32 +2,26 @@ package share.fare.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 
 @Entity(name = "user_table")
 @Getter
 @Setter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User implements UserDetails {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+public class User extends BaseEntity implements UserDetails {
     private String email;
     private String password;
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    private LocalDate createdAt;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private UserInfo userInfo;
@@ -41,11 +35,6 @@ public class User implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(role.name()));
-    }
-
-    @PrePersist
-    public void prePersist() {
-        createdAt = LocalDate.now();
     }
 
     @Override

--- a/backend/src/main/java/share/fare/backend/entity/Vote.java
+++ b/backend/src/main/java/share/fare/backend/entity/Vote.java
@@ -1,0 +1,36 @@
+package share.fare.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Vote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @Enumerated(EnumType.STRING)
+    private VoteType voteType;
+
+    private LocalDateTime votedAt;
+
+    @PrePersist
+    public void prePersist() {
+        votedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/share/fare/backend/entity/Vote.java
+++ b/backend/src/main/java/share/fare/backend/entity/Vote.java
@@ -2,6 +2,7 @@ package share.fare.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
@@ -10,12 +11,8 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class Vote {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+@SuperBuilder
+public class Vote extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -28,11 +25,4 @@ public class Vote {
     private VoteType voteType;
 
     private LocalDateTime votedAt;
-
-    @PrePersist
-    public void prePersist() {
-        votedAt = LocalDateTime.now();
-    }
 }
-
-// TODO: add base entity and move prePersist there

--- a/backend/src/main/java/share/fare/backend/entity/Vote.java
+++ b/backend/src/main/java/share/fare/backend/entity/Vote.java
@@ -34,3 +34,5 @@ public class Vote {
         votedAt = LocalDateTime.now();
     }
 }
+
+// TODO: add base entity and move prePersist there

--- a/backend/src/main/java/share/fare/backend/entity/VoteType.java
+++ b/backend/src/main/java/share/fare/backend/entity/VoteType.java
@@ -1,0 +1,6 @@
+package share.fare.backend.entity;
+
+public enum VoteType {
+    FOR,
+    AGAINST
+}

--- a/backend/src/main/java/share/fare/backend/exception/ActionIsNotAllowedException.java
+++ b/backend/src/main/java/share/fare/backend/exception/ActionIsNotAllowedException.java
@@ -1,0 +1,11 @@
+package share.fare.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.FORBIDDEN)
+public class ActionIsNotAllowedException extends RuntimeException {
+    public ActionIsNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/exception/ActivityNotFoundException.java
+++ b/backend/src/main/java/share/fare/backend/exception/ActivityNotFoundException.java
@@ -1,0 +1,14 @@
+package share.fare.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when an activity is not found.
+ */
+@ResponseStatus(code = HttpStatus.NOT_FOUND)
+public class ActivityNotFoundException extends RuntimeException {
+    public ActivityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/exception/DuplicateVoteException.java
+++ b/backend/src/main/java/share/fare/backend/exception/DuplicateVoteException.java
@@ -1,0 +1,14 @@
+package share.fare.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a user tries to vote multiple times for the same activity.
+ */
+@ResponseStatus(code = HttpStatus.CONFLICT)
+public class DuplicateVoteException extends RuntimeException {
+    public DuplicateVoteException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/exception/FareShareResponseEntityExceptionHandler.java
+++ b/backend/src/main/java/share/fare/backend/exception/FareShareResponseEntityExceptionHandler.java
@@ -136,9 +136,35 @@ public class FareShareResponseEntityExceptionHandler extends ResponseEntityExcep
     @ExceptionHandler(ActivityNotFoundException.class)
     public final ResponseEntity<ErrorDetails> activityNotFoundException(Exception ex, WebRequest request) {
         ErrorDetails errorDetails = new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false), ex.getStackTrace().length);
-        return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(errorDetails, HttpStatus.NOT_FOUND);
     }
 
+    /**
+     * Global exception for duplicate vote
+     */
+    @ExceptionHandler(DuplicateVoteException.class)
+    public final ResponseEntity<ErrorDetails> duplicateVoteException(Exception ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false), ex.getStackTrace().length);
+        return new ResponseEntity<>(errorDetails, HttpStatus.CONFLICT);
+    }
+
+    /**
+     * Global exception for vote not found
+     */
+    @ExceptionHandler(VoteNotFoundException.class)
+    public final ResponseEntity<ErrorDetails> voteNotFoundException(Exception ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false), ex.getStackTrace().length);
+        return new ResponseEntity<>(errorDetails, HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * Global exception for action not allowed
+     */
+    @ExceptionHandler(ActionIsNotAllowedException.class)
+    public final ResponseEntity<ErrorDetails> actionNotAllowedException(Exception ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false), ex.getStackTrace().length);
+        return new ResponseEntity<>(errorDetails, HttpStatus.FORBIDDEN);
+    }
 }
 
 

--- a/backend/src/main/java/share/fare/backend/exception/FareShareResponseEntityExceptionHandler.java
+++ b/backend/src/main/java/share/fare/backend/exception/FareShareResponseEntityExceptionHandler.java
@@ -130,4 +130,16 @@ public class FareShareResponseEntityExceptionHandler extends ResponseEntityExcep
         return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
     }
 
+    /**
+     * Global exception for not found activity
+     */
+    @ExceptionHandler(ActivityNotFoundException.class)
+    public final ResponseEntity<ErrorDetails> activityNotFoundException(Exception ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false), ex.getStackTrace().length);
+        return new ResponseEntity<>(errorDetails, HttpStatus.BAD_REQUEST);
+    }
+
 }
+
+
+// TODO: Improve the java docs here

--- a/backend/src/main/java/share/fare/backend/exception/VoteNotFoundException.java
+++ b/backend/src/main/java/share/fare/backend/exception/VoteNotFoundException.java
@@ -1,0 +1,11 @@
+package share.fare.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND)
+public class VoteNotFoundException extends RuntimeException {
+    public VoteNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/mapper/ActivityMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/ActivityMapper.java
@@ -1,0 +1,4 @@
+package share.fare.backend.mapper;
+
+public class ActivityMapper {
+}

--- a/backend/src/main/java/share/fare/backend/mapper/ActivityMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/ActivityMapper.java
@@ -1,4 +1,57 @@
 package share.fare.backend.mapper;
 
+import share.fare.backend.dto.request.ActivityRequest;
+import share.fare.backend.dto.response.ActivityResponse;
+import share.fare.backend.dto.response.VoteResponse;
+import share.fare.backend.entity.Activity;
+import share.fare.backend.entity.Group;
+import share.fare.backend.entity.Vote;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ActivityMapper {
+    public static ActivityResponse toResponse(Activity activity) {
+        if (activity == null) {
+            return null;
+        }
+
+        return ActivityResponse.builder()
+                .id(activity.getId())
+                .name(activity.getName())
+                .description(activity.getDescription())
+                .location(activity.getLocation())
+                .link(activity.getLink())
+                .groupId(activity.getGroup() != null ? activity.getGroup().getId() : null)
+                .createdAt(activity.getCreatedAt())
+                .votes(mapVotes(activity.getVotes()))
+                .build();
+    }
+
+    public static Activity toEntity(ActivityRequest request, Group group) {
+        if (request == null) {
+            return null;
+        }
+
+        return Activity.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .location(request.getLocation())
+                .link(request.getLink())
+                .group(group)
+                .votes(new ArrayList<>())
+                .build();
+    }
+
+    private static List<VoteResponse> mapVotes(List<Vote> votes) {
+        if (votes == null) {
+            return Collections.emptyList();
+        }
+
+        return votes.stream()
+                .map(VoteMapper::toResponse)
+                .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/share/fare/backend/mapper/ActivityMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/ActivityMapper.java
@@ -54,4 +54,14 @@ public class ActivityMapper {
                 .map(VoteMapper::toResponse)
                 .collect(Collectors.toList());
     }
+
+    protected static List<ActivityResponse> mapActivities(List<Activity> activities) {
+        if (activities == null) {
+            return Collections.emptyList();
+        }
+
+        return activities.stream()
+                .map(ActivityMapper::toResponse)
+                .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/share/fare/backend/mapper/GroupMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/GroupMapper.java
@@ -30,6 +30,7 @@ public class GroupMapper {
                 .groupImageUrl(group.getGroupImageUrl())
                 .links(group.getLinks())
                 .memberships(mapMemberships(group.getMemberships()))
+                .activities(ActivityMapper.mapActivities(group.getActivities()))
                 .build();
     }
 

--- a/backend/src/main/java/share/fare/backend/mapper/UserMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/UserMapper.java
@@ -5,6 +5,7 @@ import share.fare.backend.dto.response.UserResponse;
 import share.fare.backend.entity.User;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 
 public class UserMapper {
@@ -12,7 +13,7 @@ public class UserMapper {
         return User.builder()
                 .email(userRequest.getEmail())
                 .password(userRequest.getPassword())
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/backend/src/main/java/share/fare/backend/mapper/VoteMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/VoteMapper.java
@@ -1,0 +1,4 @@
+package share.fare.backend.mapper;
+
+public class VoteMapper {
+}

--- a/backend/src/main/java/share/fare/backend/mapper/VoteMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/VoteMapper.java
@@ -1,4 +1,36 @@
 package share.fare.backend.mapper;
 
+import share.fare.backend.dto.request.VoteRequest;
+import share.fare.backend.dto.response.VoteResponse;
+import share.fare.backend.entity.Activity;
+import share.fare.backend.entity.User;
+import share.fare.backend.entity.Vote;
+
 public class VoteMapper {
+    public static VoteResponse toResponse(Vote vote) {
+        if (vote == null) {
+            return null;
+        }
+
+        return VoteResponse.builder()
+                .id(vote.getId())
+                .userId(vote.getUser() != null ? vote.getUser().getId() : null)
+                .userEmail(vote.getUser() != null ? vote.getUser().getEmail() : null)
+                .activityId(vote.getActivity() != null ? vote.getActivity().getId() : null)
+                .voteType(vote.getVoteType())
+                .votedAt(vote.getVotedAt())
+                .build();
+    }
+
+    public static Vote toEntity(VoteRequest request, Activity activity, User user) {
+        if (request == null) {
+            return null;
+        }
+
+        return Vote.builder()
+                .voteType(request.getVoteType())
+                .activity(activity)
+                .user(user)
+                .build();
+    }
 }

--- a/backend/src/main/java/share/fare/backend/repository/ActivityRepository.java
+++ b/backend/src/main/java/share/fare/backend/repository/ActivityRepository.java
@@ -1,0 +1,11 @@
+package share.fare.backend.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import share.fare.backend.entity.Activity;
+
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+    Page<Activity> findByGroup_Id(Long groupId, Pageable pageable);
+}

--- a/backend/src/main/java/share/fare/backend/repository/VoteRepository.java
+++ b/backend/src/main/java/share/fare/backend/repository/VoteRepository.java
@@ -1,0 +1,7 @@
+package share.fare.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import share.fare.backend.entity.Vote;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+}

--- a/backend/src/main/java/share/fare/backend/repository/VoteRepository.java
+++ b/backend/src/main/java/share/fare/backend/repository/VoteRepository.java
@@ -11,4 +11,6 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     boolean existsByActivityAndUser(Activity activity, User user);
 
     Optional<Vote> findByActivity(Activity activity);
+
+    Optional<Vote> findByIdAndUser_Id(Long voteId, Long userId);
 }

--- a/backend/src/main/java/share/fare/backend/repository/VoteRepository.java
+++ b/backend/src/main/java/share/fare/backend/repository/VoteRepository.java
@@ -1,7 +1,14 @@
 package share.fare.backend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import share.fare.backend.entity.Activity;
+import share.fare.backend.entity.User;
 import share.fare.backend.entity.Vote;
 
+import java.util.Optional;
+
 public interface VoteRepository extends JpaRepository<Vote, Long> {
+    boolean existsByActivityAndUser(Activity activity, User user);
+
+    Optional<Vote> findByActivity(Activity activity);
 }

--- a/backend/src/main/java/share/fare/backend/service/ActivityService.java
+++ b/backend/src/main/java/share/fare/backend/service/ActivityService.java
@@ -1,0 +1,62 @@
+package share.fare.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import share.fare.backend.dto.request.ActivityRequest;
+import share.fare.backend.dto.response.ActivityResponse;
+import share.fare.backend.entity.Activity;
+import share.fare.backend.entity.Group;
+import share.fare.backend.entity.User;
+import share.fare.backend.exception.ActivityNotFoundException;
+import share.fare.backend.exception.GroupNotFoundException;
+import share.fare.backend.exception.UserNotFoundException;
+import share.fare.backend.mapper.ActivityMapper;
+import share.fare.backend.repository.ActivityRepository;
+import share.fare.backend.repository.GroupRepository;
+import share.fare.backend.repository.UserRepository;
+import share.fare.backend.repository.VoteRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityService {
+    private final ActivityRepository activityRepository;
+    private final GroupRepository groupRepository;
+    private final UserRepository userRepository;
+    private final VoteRepository voteRepository;
+
+    public ActivityResponse createActivity(ActivityRequest activityRequest, Long createdByUserId, Long groupId) {
+        Group group = groupRepository
+                .findById(groupId)
+                .orElseThrow(() -> new GroupNotFoundException("Group with ID " + groupId + " not found"));
+
+        User user = userRepository
+                .findById(createdByUserId)
+                .orElseThrow(() -> new UserNotFoundException("User with ID " + createdByUserId + " not found"));
+
+        Activity activity = ActivityMapper.toEntity(activityRequest, group);
+
+        return ActivityMapper.toResponse(activityRepository.save(activity));
+    }
+
+    public ActivityResponse updateActivity(ActivityRequest request, Long activityId) {
+        Activity activity = activityRepository
+                .findById(activityId)
+                .orElseThrow(() -> new ActivityNotFoundException("Activity with ID: " + activityId + " not found"));
+
+        activity.setName(request.getName());
+        activity.setDescription(request.getDescription());
+        activity.setLink(request.getLink());
+
+        return ActivityMapper.toResponse(activityRepository.save(activity));
+    }
+
+    public void deleteActivity(Long activityId) {
+        activityRepository.deleteById(activityId);
+    }
+
+    public Page<ActivityResponse> getActivitiesForGroup(Long groupId, Pageable pageable) {
+        return activityRepository.findByGroup_Id(groupId, pageable).map(ActivityMapper::toResponse);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/service/AuthenticationService.java
+++ b/backend/src/main/java/share/fare/backend/service/AuthenticationService.java
@@ -18,6 +18,7 @@ import share.fare.backend.exception.UserNotFoundException;
 import share.fare.backend.repository.UserRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +42,7 @@ public class AuthenticationService {
                 .email(registerRequest.getEmail())
                 .password(passwordEncoder.encode(registerRequest.getPassword()))
                 .role(Role.USER)
-                .createdAt(LocalDate.now())
+                .createdAt(LocalDateTime.now())
                 .build();
 
         UserInfo userInfo = UserInfo.builder()

--- a/backend/src/main/java/share/fare/backend/service/VoteService.java
+++ b/backend/src/main/java/share/fare/backend/service/VoteService.java
@@ -1,0 +1,74 @@
+package share.fare.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import share.fare.backend.dto.request.VoteRequest;
+import share.fare.backend.dto.response.VoteResponse;
+import share.fare.backend.entity.Activity;
+import share.fare.backend.entity.User;
+import share.fare.backend.entity.Vote;
+import share.fare.backend.exception.*;
+import share.fare.backend.mapper.VoteMapper;
+import share.fare.backend.repository.ActivityRepository;
+import share.fare.backend.repository.UserRepository;
+import share.fare.backend.repository.VoteRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class VoteService {
+    private final VoteRepository voteRepository;
+    private final ActivityRepository activityRepository;
+    private final UserRepository userRepository;
+
+    public VoteResponse addVote(Long activityId, Long userId, VoteRequest voteRequest) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new ActivityNotFoundException("Activity not found with ID: " + activityId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("User not found with ID: " + userId));
+
+        if (voteRepository.existsByActivityAndUser(activity, user)) {
+            throw new DuplicateVoteException("User has already voted on this activity");
+        }
+
+        Vote vote = VoteMapper.toEntity(voteRequest, activity, user);
+        Vote savedVote = voteRepository.save(vote);
+        return VoteMapper.toResponse(savedVote);
+    }
+
+    public List<VoteResponse> getVotesForActivity(Long activityId) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new ActivityNotFoundException("Activity not found with ID: " + activityId));
+
+        return voteRepository.findByActivity(activity).stream()
+                .map(VoteMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public VoteResponse updateVote(Long voteId, Long userId, VoteRequest request) {
+        Vote vote = voteRepository.findById(voteId)
+                .orElseThrow(() -> new VoteNotFoundException("Vote not found with ID: " + voteId));
+
+        if (!vote.getUser().getId().equals(userId)) {
+            throw new ActionIsNotAllowedException("You are not authorized to update this vote");
+        }
+
+        vote.setVoteType(request.getVoteType());
+        Vote updatedVote = voteRepository.save(vote);
+        return VoteMapper.toResponse(updatedVote);
+    }
+
+    public void deleteVote(Long voteId, Long userId) {
+        Vote vote = voteRepository.findById(voteId)
+                .orElseThrow(() -> new VoteNotFoundException("Vote not found with ID: " + voteId));
+
+        if (!vote.getUser().getId().equals(userId)) {
+            throw new ActionIsNotAllowedException("You are not authorized to delete this vote");
+        }
+
+        voteRepository.delete(vote);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/service/VoteService.java
+++ b/backend/src/main/java/share/fare/backend/service/VoteService.java
@@ -10,6 +10,7 @@ import share.fare.backend.entity.Vote;
 import share.fare.backend.exception.*;
 import share.fare.backend.mapper.VoteMapper;
 import share.fare.backend.repository.ActivityRepository;
+import share.fare.backend.repository.GroupMembershipRepository;
 import share.fare.backend.repository.UserRepository;
 import share.fare.backend.repository.VoteRepository;
 
@@ -22,6 +23,7 @@ public class VoteService {
     private final VoteRepository voteRepository;
     private final ActivityRepository activityRepository;
     private final UserRepository userRepository;
+    private final GroupMembershipRepository groupMembershipRepository;
 
     public VoteResponse addVote(Long activityId, Long userId, VoteRequest voteRequest) {
         Activity activity = activityRepository.findById(activityId)
@@ -32,6 +34,10 @@ public class VoteService {
 
         if (voteRepository.existsByActivityAndUser(activity, user)) {
             throw new DuplicateVoteException("User has already voted on this activity");
+        }
+
+        if (!groupMembershipRepository.existsByGroupAndUser(activity.getGroup(), user)) {
+            throw new UserIsNotInGroupException("User with ID: " + userId + " is not a member of the group");
         }
 
         Vote vote = VoteMapper.toEntity(voteRequest, activity, user);

--- a/backend/src/main/resources/fare share.postman_collection.json
+++ b/backend/src/main/resources/fare share.postman_collection.json
@@ -17,7 +17,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"email\": \"user2@example.com\",\n    \"password\": \"password2\"\n}",
+							"raw": "{\n    \"email\": \"user@example.com\",\n    \"password\": \"password\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -62,7 +62,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMkBleGFtcGxlLmNvbSIsImlhdCI6MTczODMyOTY0OCwiZXhwIjoxNzM4MzY1NjQ4fQ.WKmHyRUj11vKpg-jazf9eqfAyyQFJVBfZ2AiIKrlStc",
+									"value": "{{jwt-token}}",
 									"type": "string"
 								}
 							]
@@ -265,16 +265,6 @@
 				{
 					"name": "get all groups",
 					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIiwiaWF0IjoxNzM4MzIxNzY0LCJleHAiOjE3MzgzNTc3NjR9.GSDwpHhfiM3U-hhTXAduSLO4-xcCOxehbeBIfRVpQyA",
-									"type": "string"
-								}
-							]
-						},
 						"method": "GET",
 						"header": [],
 						"url": {
@@ -296,7 +286,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIiwiaWF0IjoxNzM4MzIxNzY0LCJleHAiOjE3MzgzNTc3NjR9.GSDwpHhfiM3U-hhTXAduSLO4-xcCOxehbeBIfRVpQyA",
+									"value": "{{jwt-token}}",
 									"type": "string"
 								}
 							]
@@ -402,6 +392,499 @@
 						}
 					},
 					"response": []
+				}
+			],
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "{{jwt-token}}",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "activities",
+			"item": [
+				{
+					"name": "add activity",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"disney land\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "/api/v1/groups/1/activities",
+							"path": [
+								"api",
+								"v1",
+								"groups",
+								"1",
+								"activities"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "update activity",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "/api/v1/groups/1/activities/1",
+							"path": [
+								"api",
+								"v1",
+								"groups",
+								"1",
+								"activities",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete activity",
+					"request": {
+						"method": "DELETE",
+						"header": []
+					},
+					"response": []
+				},
+				{
+					"name": "get group activities",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/groups/1/activities",
+							"path": [
+								"api",
+								"v1",
+								"groups",
+								"1",
+								"activities"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMkBleGFtcGxlLmNvbSIsImlhdCI6MTczODQyMTEzNiwiZXhwIjoxNzM4NDU3MTM2fQ.tpadIbJpJObqkPrsY7Tf9ihNjkZBVUuJnW41h_Dqc28",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "friend-invitations",
+			"item": [
+				{
+					"name": "send friend invitation",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt-token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/friend-invitations/send?receiverId=1",
+							"path": [
+								"api",
+								"v1",
+								"friend-invitations",
+								"send"
+							],
+							"query": [
+								{
+									"key": "receiverId",
+									"value": "1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get sent friend invitations",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt-token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/friend-invitations/sent",
+							"path": [
+								"api",
+								"v1",
+								"friend-invitations",
+								"sent"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get received friend invitations",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt-token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/friend-invitations/received",
+							"path": [
+								"api",
+								"v1",
+								"friend-invitations",
+								"received"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "group-invitations",
+			"item": [
+				{
+					"name": "send group invitation",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt-token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/group-invitations/send?receiverId=1&groupId=1",
+							"path": [
+								"api",
+								"v1",
+								"group-invitations",
+								"send"
+							],
+							"query": [
+								{
+									"key": "receiverId",
+									"value": "1"
+								},
+								{
+									"key": "groupId",
+									"value": "1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get sent group invitations",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt-token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/group-invitations/sent",
+							"path": [
+								"api",
+								"v1",
+								"group-invitations",
+								"sent"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get received group invitations",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt-token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/group-invitations/received",
+							"path": [
+								"api",
+								"v1",
+								"group-invitations",
+								"received"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "votes",
+			"item": [
+				{
+					"name": "vote for activity",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIiwiaWF0IjoxNzM4NDIzODAwLCJleHAiOjE3Mzg0NTk4MDB9.87eXmxVaVd8yeCbx-kQNZAA_QqgiP1ElsVPXn2iQB3A",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"voteType\": \"FOR\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "/api/v1/groups/1/activities/1/votes",
+							"path": [
+								"api",
+								"v1",
+								"groups",
+								"1",
+								"activities",
+								"1",
+								"votes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "vote against",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"voteType\": \"FOR\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get votes for activity",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/groups/1/activities/1/votes",
+							"path": [
+								"api",
+								"v1",
+								"groups",
+								"1",
+								"activities",
+								"1",
+								"votes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "update vote",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/groups/1/activities/1/votes/1",
+							"path": [
+								"api",
+								"v1",
+								"groups",
+								"1",
+								"activities",
+								"1",
+								"votes",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete vote",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "/api/v1/groups/1/activities/1/votes/1",
+							"path": [
+								"api",
+								"v1",
+								"groups",
+								"1",
+								"activities",
+								"1",
+								"votes",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "{{jwt-token}}",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
 				}
 			]
 		}


### PR DESCRIPTION
# Add Attractions and Voting to Groups  

## Changes  
- Added **attractions (activities)** to existing groups, allowing users to create, update, delete, and list activities within a group.  
- Implemented **voting system** where group members can vote **for** or **against** an activity.  
- **New Controllers:**  
  - `ActivityController`: Handles CRUD operations for group activities.  
  - `VoteController`: Allows users to cast, update, retrieve, and delete votes on activities.  

## API Endpoints  
- **Activities:**  
  - `POST /api/v1/groups/{groupId}/activities` → Add activity to a group.  
  - `GET /api/v1/groups/{groupId}/activities` → List activities in a group (paginated).  
  - `PUT /api/v1/groups/{groupId}/activities/{activityId}` → Update activity.  
  - `DELETE /api/v1/groups/{groupId}/activities/{activityId}` → Remove activity.  

- **Votes:**  
  - `POST /api/v1/groups/{groupId}/activities/{activityId}/votes` → Vote on an activity.  
  - `GET /api/v1/groups/{groupId}/activities/{activityId}/votes` → Get votes for an activity.  
  - `PUT /api/v1/groups/{groupId}/activities/{activityId}/votes/{voteId}` → Update vote.  
  - `DELETE /api/v1/groups/{groupId}/activities/{activityId}/votes/{voteId}` → Remove vote.  

## Notes  
- Users can only vote on activities within their assigned groups.  
- Voting is tied to user authentication, ensuring votes are unique per user per activity.  
- Activities are paginated and sorted by creation date in descending order.