### PR TITLE
Backend/fix invitations

### DIFF
--- a/backend/src/main/java/share/fare/backend/config/DataInitializer.java
+++ b/backend/src/main/java/share/fare/backend/config/DataInitializer.java
@@ -53,12 +53,28 @@ public class DataInitializer implements ApplicationListener<ContextRefreshedEven
                     .createdAt(LocalDateTime.now())
                     .build();
 
+            UserInfo userInfo2 = UserInfo.builder()
+                    .firstName("Test2")
+                    .lastName("User2")
+                    .user(user2)
+                    .build();
+
+            user2.setUserInfo(userInfo2);
+
             User user3 = User.builder()
                     .email("user3@example.com")
                     .password(passwordEncoder.encode("password3"))
                     .role(Role.USER)
                     .createdAt(LocalDateTime.now())
                     .build();
+
+            UserInfo userInfo3 = UserInfo.builder()
+                    .firstName("Test3")
+                    .lastName("User3")
+                    .user(user3)
+                    .build();
+
+            user3.setUserInfo(userInfo3);
 
             userRepository.saveAll(List.of(user1, user2, user3));
 

--- a/backend/src/main/java/share/fare/backend/dto/response/GroupInvitationResponse.java
+++ b/backend/src/main/java/share/fare/backend/dto/response/GroupInvitationResponse.java
@@ -9,5 +9,6 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class GroupInvitationResponse extends InvitationResponse {
     private Long groupId;
+    private String groupName;
 }
 

--- a/backend/src/main/java/share/fare/backend/dto/response/InvitationResponse.java
+++ b/backend/src/main/java/share/fare/backend/dto/response/InvitationResponse.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class InvitationResponse {
     private Long id;
-    private Long senderId;
-    private Long receiverId;
+    private UserGeneralResponse sender;
+    private UserGeneralResponse receiver;
     private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/share/fare/backend/entity/Group.java
+++ b/backend/src/main/java/share/fare/backend/entity/Group.java
@@ -45,6 +45,9 @@ public class Group extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Activity> activities = new ArrayList<>();
 
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GroupInvitation> invitations = new ArrayList<>();
+
     public void addMember(User user, GroupRole role) {
         GroupMembership membership = GroupMembership.builder()
                 .user(user)

--- a/backend/src/main/java/share/fare/backend/entity/User.java
+++ b/backend/src/main/java/share/fare/backend/entity/User.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -36,6 +37,18 @@ public class User extends BaseEntity implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
     }
+
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Invitation> invitationsSent = new ArrayList<>();
+
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Invitation> invitationsReceived = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user1", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friendship> friendshipsInitiated = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user2", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friendship> friendshipsAccepted = new ArrayList<>();
 
     @Override
     public String getUsername() {

--- a/backend/src/main/java/share/fare/backend/exception/FareShareResponseEntityExceptionHandler.java
+++ b/backend/src/main/java/share/fare/backend/exception/FareShareResponseEntityExceptionHandler.java
@@ -84,6 +84,12 @@ public class FareShareResponseEntityExceptionHandler extends ResponseEntityExcep
         return new ResponseEntity<>(errorDetails, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(FriendshipAlreadyExistsException.class)
+    public final ResponseEntity<ErrorDetails> handleFriendshipAlreadyExistsException(Exception ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false), ex.getStackTrace().length);
+        return new ResponseEntity<>(errorDetails, HttpStatus.CONFLICT);
+    }
+
     @ExceptionHandler(ActivityNotFoundException.class)
     public final ResponseEntity<ErrorDetails> activityNotFoundException(Exception ex, WebRequest request) {
         ErrorDetails errorDetails = new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false), ex.getStackTrace().length);

--- a/backend/src/main/java/share/fare/backend/exception/FriendshipAlreadyExistsException.java
+++ b/backend/src/main/java/share/fare/backend/exception/FriendshipAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package share.fare.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.CONFLICT)
+public class FriendshipAlreadyExistsException extends RuntimeException {
+    public FriendshipAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/share/fare/backend/mapper/FriendInvitationMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/FriendInvitationMapper.java
@@ -4,11 +4,12 @@ import share.fare.backend.dto.response.FriendInvitationResponse;
 import share.fare.backend.entity.FriendInvitation;
 
 public class FriendInvitationMapper {
+
     public static FriendInvitationResponse toResponse(FriendInvitation invitation) {
         return FriendInvitationResponse.builder()
                 .id(invitation.getId())
-                .senderId(invitation.getSender().getId())
-                .receiverId(invitation.getReceiver().getId())
+                .sender(UserMapper.toGeneralResponse(invitation.getSender()))
+                .receiver(UserMapper.toGeneralResponse(invitation.getReceiver()))
                 .createdAt(invitation.getCreatedAt())
                 .build();
     }

--- a/backend/src/main/java/share/fare/backend/mapper/GroupInvitationMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/GroupInvitationMapper.java
@@ -10,6 +10,7 @@ public class GroupInvitationMapper {
                 .sender(UserMapper.toGeneralResponse(invitation.getSender()))
                 .receiver(UserMapper.toGeneralResponse(invitation.getReceiver()))
                 .groupId(invitation.getGroup().getId())
+                .groupName(invitation.getGroup().getName())
                 .createdAt(invitation.getCreatedAt())
                 .build();
     }

--- a/backend/src/main/java/share/fare/backend/mapper/GroupInvitationMapper.java
+++ b/backend/src/main/java/share/fare/backend/mapper/GroupInvitationMapper.java
@@ -7,8 +7,8 @@ public class GroupInvitationMapper {
     public static GroupInvitationResponse toResponse(GroupInvitation invitation) {
         return GroupInvitationResponse.builder()
                 .id(invitation.getId())
-                .senderId(invitation.getSender().getId())
-                .receiverId(invitation.getReceiver().getId())
+                .sender(UserMapper.toGeneralResponse(invitation.getSender()))
+                .receiver(UserMapper.toGeneralResponse(invitation.getReceiver()))
                 .groupId(invitation.getGroup().getId())
                 .createdAt(invitation.getCreatedAt())
                 .build();

--- a/backend/src/main/java/share/fare/backend/repository/FriendshipRepository.java
+++ b/backend/src/main/java/share/fare/backend/repository/FriendshipRepository.java
@@ -17,5 +17,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Friendsh
             "    UNION " +
             "    SELECT f.id.user2Id FROM Friendship f WHERE f.id.user1Id = :userId)")
     List<User> findFriendsByUserId(@Param("userId") Long userId);
+
+    boolean existsById(FriendshipId id);
 }
 

--- a/backend/src/main/java/share/fare/backend/service/FriendInvitationService.java
+++ b/backend/src/main/java/share/fare/backend/service/FriendInvitationService.java
@@ -41,6 +41,10 @@ public class FriendInvitationService {
             throw new InvitationAlreadyExistsException("Friend invitation already exists.");
         }
 
+        if (invitationRepository.existsBySenderIdAndReceiverId(receiverId, senderId)) {
+            throw new InvitationAlreadyExistsException("Friend invitation already exists.");
+        }
+
         User sender = userRepository.findById(senderId)
                 .orElseThrow(() -> new UserNotFoundException(senderId));
 

--- a/backend/src/main/java/share/fare/backend/service/FriendInvitationService.java
+++ b/backend/src/main/java/share/fare/backend/service/FriendInvitationService.java
@@ -37,12 +37,13 @@ public class FriendInvitationService {
             throw new ActionIsNotAllowedException("You cannot send a friend invitation to yourself.");
         }
 
-        if (invitationRepository.existsBySenderIdAndReceiverId(senderId, receiverId)) {
+        if (invitationRepository.existsBySenderIdAndReceiverId(senderId, receiverId) ||
+                invitationRepository.existsBySenderIdAndReceiverId(receiverId, senderId)) {
             throw new InvitationAlreadyExistsException("Friend invitation already exists.");
         }
 
-        if (invitationRepository.existsBySenderIdAndReceiverId(receiverId, senderId)) {
-            throw new InvitationAlreadyExistsException("Friend invitation already exists.");
+        if (friendshipRepository.existsById(new FriendshipId(senderId, receiverId))) {
+            throw new FriendshipAlreadyExistsException("Friendship already exists.");
         }
 
         User sender = userRepository.findById(senderId)

--- a/backend/src/main/java/share/fare/backend/service/GroupInvitationService.java
+++ b/backend/src/main/java/share/fare/backend/service/GroupInvitationService.java
@@ -42,7 +42,6 @@ public class GroupInvitationService {
                 .orElseThrow(() -> new UserNotFoundException(senderId));
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupNotFoundException(groupId));
-
         User receiver = userRepository.findById(receiverId)
                 .orElseThrow(() -> new UserNotFoundException(receiverId));
 

--- a/backend/src/main/java/share/fare/backend/service/GroupInvitationService.java
+++ b/backend/src/main/java/share/fare/backend/service/GroupInvitationService.java
@@ -37,6 +37,7 @@ public class GroupInvitationService {
         if (invitationRepository.existsBySenderIdAndReceiverIdAndGroupId(senderId, receiverId, groupId)) {
             throw new InvitationAlreadyExistsException("Group invitation already exists.");
         }
+
         User sender = userRepository.findById(senderId)
                 .orElseThrow(() -> new UserNotFoundException(senderId));
         Group group = groupRepository.findById(groupId)
@@ -48,6 +49,12 @@ public class GroupInvitationService {
         if (!group.getMemberships().stream()
                 .map(GroupMembership::getUser).toList().contains(sender)) {
             throw new UserIsNotInGroupException("Sender does not belong to group.");
+        }
+
+        if (group.getMemberships().stream()
+                .map(GroupMembership::getUser)
+                .toList().contains(receiver)) {
+            throw new ActionIsNotAllowedException("Receiver is already a member of the group.");
         }
 
         GroupInvitation invitation = GroupInvitation.builder()

--- a/backend/src/test/java/share/fare/backend/controller/FriendInvitationControllerTest.java
+++ b/backend/src/test/java/share/fare/backend/controller/FriendInvitationControllerTest.java
@@ -82,8 +82,8 @@ public class FriendInvitationControllerTest {
                         .with(user(testUser))
                         .principal(() -> String.valueOf(testUser.getId())))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.senderId").value(testUser.getId()))
-                .andExpect(jsonPath("$.receiverId").value(testSecondUser.getId()));
+                .andExpect(jsonPath("$.sender.id").value(testUser.getId()))
+                .andExpect(jsonPath("$.receiver.id").value(testSecondUser.getId()));
     }
 
     @Test
@@ -194,7 +194,7 @@ public class FriendInvitationControllerTest {
                         .with(user(testUser))
                         .principal(() -> String.valueOf(testUser.getId())))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.[0].senderId").value(testUser.getId()));
+                .andExpect(jsonPath("$.[0].sender.id").value(testUser.getId()));
 
         mockMvc.perform(get(URI + "/received")
                         .with(user(testUser))
@@ -223,6 +223,6 @@ public class FriendInvitationControllerTest {
                         .with(user(testSecondUser))
                         .principal(() -> String.valueOf(testSecondUser.getId())))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.[0].senderId").value(testUser.getId()));
+                .andExpect(jsonPath("$.[0].sender.id").value(testUser.getId()));
     }
 }

--- a/backend/src/test/java/share/fare/backend/controller/GroupInvitationControllerTest.java
+++ b/backend/src/test/java/share/fare/backend/controller/GroupInvitationControllerTest.java
@@ -105,8 +105,8 @@ public class GroupInvitationControllerTest {
                         .param("receiverId", String.valueOf(testSecondUser.getId()))
                         .param("groupId", String.valueOf(testGroup.getId())))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.senderId").value(testUser.getId()))
-                .andExpect(jsonPath("$.receiverId").value(testSecondUser.getId()))
+                .andExpect(jsonPath("$.sender.id").value(testUser.getId()))
+                .andExpect(jsonPath("$.receiver.id").value(testSecondUser.getId()))
                 .andExpect(jsonPath("$.groupId").value(testGroup.getId()));
     }
 
@@ -248,7 +248,7 @@ public class GroupInvitationControllerTest {
                         .with(user(testUser))
                         .principal(() -> String.valueOf(testUser.getId())))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.[0].senderId").value(testUser.getId()));
+                .andExpect(jsonPath("$.[0].sender.id").value(testUser.getId()));
 
         mockMvc.perform(get(URI + "/received")
                         .with(user(testUser))
@@ -278,6 +278,6 @@ public class GroupInvitationControllerTest {
                         .with(user(testSecondUser))
                         .principal(() -> String.valueOf(testSecondUser.getId())))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.[0].senderId").value(testUser.getId()));
+                .andExpect(jsonPath("$.[0].sender.id").value(testUser.getId()));
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Initialize user information for seeded users and enhance invitation services by adding validation to prevent duplicate and invalid invitations.

Bug Fixes:
- Initialize UserInfo for seeded users in the data initializer to ensure user entities have associated profile information
- Prevent reverse duplicate friend invitations by checking for existing invitations from the receiver to the sender

Enhancements:
- Disallow group invitations when the recipient is already a member of the group