### PR TITLE
Frontend/modals interceptor

### DIFF
--- a/frontend/app/(auth)/sign-in/page.tsx
+++ b/frontend/app/(auth)/sign-in/page.tsx
@@ -36,12 +36,8 @@ function Page() {
 
       window.location.href = '/trips';
       resetForm();
-    } catch (err: unknown) {
-      setError(
-        `${
-          err.response?.data?.message || 'Something went wrong'
-        }. Please try again.`,
-      );
+    } catch {
+      setError('Something went wrong');
       resetForm();
     }
   };

--- a/frontend/app/(auth)/sign-in/page.tsx
+++ b/frontend/app/(auth)/sign-in/page.tsx
@@ -25,10 +25,7 @@ function Page() {
     },
   ) => {
     try {
-      const result = await axios.post(
-        'http://localhost:8080/auth/login',
-        values,
-      );
+      const result = await axios.post('/auth/login', values);
       const parsedResult = authApiSchema.safeParse(result.data);
       if (!parsedResult.success) {
         setError('Invalid response from server. Please try again.');

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -33,12 +33,8 @@ const handleSignUp = async (
     setToken(token);
     window.location.href = '/trips';
     resetForm();
-  } catch (err: unknown) {
-    setError(
-      `${
-        err.response?.data?.message || 'Something went wrong'
-      }. Please try again.`,
-    );
+  } catch {
+    setError('Something went wrong.');
     resetForm();
   }
 };

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -24,10 +24,7 @@ const handleSignUp = async (
 ) => {
   try {
     console.log(values);
-    const result = await axios.post(
-      'http://localhost:8080/auth/register',
-      values,
-    );
+    const result = await axios.post('/auth/register', values);
     const parsedResult = authApiSchema.safeParse(result.data);
     if (!parsedResult.success) {
       setError('Invalid response from server. Please try again.');

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -23,7 +23,6 @@ const handleSignUp = async (
   },
 ) => {
   try {
-    console.log(values);
     const result = await axios.post('/auth/register', values);
     const parsedResult = authApiSchema.safeParse(result.data);
     if (!parsedResult.success) {

--- a/frontend/app/(root)/account/page.tsx
+++ b/frontend/app/(root)/account/page.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import { toast } from 'sonner';
 import { CircleAlert, Eye, EyeOff } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+import { logout } from '@/lib/auth';
 import axios from 'axios';
-import { getToken, logout } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
 import { Formik, Field, Form, ErrorMessage, FormikHelpers } from 'formik';
 import { Input } from '@/components/ui/input';
@@ -28,14 +29,7 @@ function Page() {
 
   const fetchUserData = async () => {
     try {
-      const token = getToken();
-      if (!token) {
-        logout();
-        return;
-      }
-      const response = await axios.get('/api/v1/users', {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const response = await axiosInstance.get('users');
       const parsedUser = UserSchema.parse(response.data);
 
       setUser(parsedUser);
@@ -52,23 +46,18 @@ function Page() {
     { resetForm }: FormikHelpers<z.infer<typeof updateEmailSchema>>,
   ) => {
     try {
-      const authResponse = await axios.post(
-        'http://localhost:8080/auth/login',
-        { email: user?.email, password: values.currentPassword },
-      );
+      const authResponse = await axios.post('/auth/login', {
+        email: user?.email,
+        password: values.currentPassword,
+      });
 
       if (authResponse.status === 200) {
         const newToken = authResponse.data.token;
 
-        const response = await axios.put(
-          '/api/v1/users',
-          { email: values.newEmail, password: values.currentPassword },
-          {
-            headers: {
-              Authorization: `Bearer ${newToken}`,
-            },
-          },
-        );
+        const response = await axiosInstance.put('users', {
+          email: values.newEmail,
+          password: values.currentPassword,
+        });
 
         setUser((prevState) => ({
           ...prevState!,
@@ -101,22 +90,17 @@ function Page() {
     { resetForm }: FormikHelpers<z.infer<typeof updatePasswordSchema>>,
   ) => {
     try {
-      const authResponse = await axios.post(
-        'http://localhost:8080/auth/login',
-        { email: user?.email, password: values.currentPassword },
-      );
+      const authResponse = await axios.post('/auth/login', {
+        email: user?.email,
+        password: values.currentPassword,
+      });
       if (authResponse.status === 200) {
         const newToken = authResponse.data.token;
 
-        await axios.put(
-          '/api/v1/users',
-          { email: user?.email, password: values.newPassword },
-          {
-            headers: {
-              Authorization: `Bearer ${newToken}`,
-            },
-          },
-        );
+        await axiosInstance.put('users', {
+          email: user?.email,
+          password: values.newPassword,
+        });
 
         resetForm();
         setIsEditingPassword(false);

--- a/frontend/app/(root)/account/page.tsx
+++ b/frontend/app/(root)/account/page.tsx
@@ -52,8 +52,6 @@ function Page() {
       });
 
       if (authResponse.status === 200) {
-        const newToken = authResponse.data.token;
-
         const response = await axiosInstance.put('users', {
           email: values.newEmail,
           password: values.currentPassword,
@@ -95,8 +93,6 @@ function Page() {
         password: values.currentPassword,
       });
       if (authResponse.status === 200) {
-        const newToken = authResponse.data.token;
-
         await axiosInstance.put('users', {
           email: user?.email,
           password: values.newPassword,

--- a/frontend/app/(root)/notifications/page.tsx
+++ b/frontend/app/(root)/notifications/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
   Card,
@@ -11,7 +11,6 @@ import {
   CardContent,
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { getToken } from '@/lib/auth';
 import { appStore } from '@/store/appStore';
 
 interface InvitationResponse {
@@ -49,24 +48,13 @@ export default function InvitationsPage() {
   );
 
   const fetchInvitations = async () => {
-    const token = getToken();
-    if (!token) return;
-
     try {
       const [friendsReceived, friendsSent, groupsReceived, groupsSent] =
         await Promise.all([
-          axios.get('/api/v1/friend-invitations/received', {
-            headers: { Authorization: `Bearer ${token}` },
-          }),
-          axios.get('/api/v1/friend-invitations/sent', {
-            headers: { Authorization: `Bearer ${token}` },
-          }),
-          axios.get('/api/v1/group-invitations/received', {
-            headers: { Authorization: `Bearer ${token}` },
-          }),
-          axios.get('/api/v1/group-invitations/sent', {
-            headers: { Authorization: `Bearer ${token}` },
-          }),
+          axiosInstance.get('friend-invitations/received'),
+          axiosInstance.get('friend-invitations/sent'),
+          axiosInstance.get('group-invitations/received'),
+          axiosInstance.get('group-invitations/sent'),
         ]);
 
       setFriendInvitesReceived(friendsReceived.data);
@@ -100,26 +88,16 @@ export default function InvitationsPage() {
     type: 'received' | 'sent',
   ) => {
     const isGroup = 'groupId' in inv;
-    const token = getToken();
 
     const handleAction = async (action: 'accept' | 'reject') => {
-      if (!token) return;
       const base = isGroup ? 'group-invitations' : 'friend-invitations';
-      const url = `/api/v1/${base}/${action}/${inv.id}`;
+      const url = `${base}/${action}/${inv.id}`;
 
       try {
         if (action === 'accept') {
-          await axios.post(
-            url,
-            {},
-            {
-              headers: { Authorization: `Bearer ${token}` },
-            },
-          );
+          await axiosInstance.post(url, {});
         } else {
-          await axios.delete(url, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
+          await axiosInstance.delete(url);
         }
 
         if (isGroup) {

--- a/frontend/app/(root)/trips/[id]/activities/[activityId]/edit/page.tsx
+++ b/frontend/app/(root)/trips/[id]/activities/[activityId]/edit/page.tsx
@@ -5,8 +5,7 @@ import { useTrip } from '@/context/TripContext';
 import { useRouter } from 'next/navigation';
 import { z } from 'zod';
 import { activityFormSchema } from '@/validation/activityFormSchema';
-import { getToken } from '@/lib/auth';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 import { useParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -47,13 +46,9 @@ export default function EditActivityPage() {
     if (!trip) return;
     try {
       if (activity && trip) {
-        const token = getToken();
-        await axios.put(
-          `/api/v1/groups/${trip.id}/activities/${params.activityId}`,
+        await axiosInstance.put(
+          `groups/${trip.id}/activities/${params.activityId}`,
           values,
-          {
-            headers: { Authorization: `Bearer ${token}` },
-          },
         );
 
         toast('Activity updated!', {

--- a/frontend/app/(root)/trips/[id]/activities/create/page.tsx
+++ b/frontend/app/(root)/trips/[id]/activities/create/page.tsx
@@ -41,8 +41,8 @@ export default function NewActivityPage() {
       refreshTrip();
 
       router.push(`/trips/${trip.id}`);
-    } catch (err: unknown) {
-      setError(err.message || 'An error occurred');
+    } catch {
+      setError('An error occurred');
     }
   };
 

--- a/frontend/app/(root)/trips/[id]/activities/create/page.tsx
+++ b/frontend/app/(root)/trips/[id]/activities/create/page.tsx
@@ -4,8 +4,7 @@ import { useState } from 'react';
 import { activityFormSchema } from '@/validation/activityFormSchema';
 import { z } from 'zod';
 import { FormikHelpers } from 'formik';
-import { getToken } from '@/lib/auth';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 import { Alert } from '@/components/ui/alert';
 import { useTrip } from '@/context/TripContext';
 import { useRouter } from 'next/navigation';
@@ -24,13 +23,9 @@ export default function NewActivityPage() {
   ) => {
     if (!trip) return;
     try {
-      const token = getToken();
-      const response = await axios.post(
-        `/api/v1/groups/${trip.id}/activities`,
+      const response = await axiosInstance.post(
+        `groups/${trip.id}/activities`,
         values,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        },
       );
       console.log(response.data);
       toast(`Activity ${values.name} added!`, {

--- a/frontend/app/(root)/trips/[id]/edit/page.tsx
+++ b/frontend/app/(root)/trips/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client';
-import React, { useEffect, useState } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import TripForm from '@/components/trip/TripForm';
 import { Alert } from '@/components/ui/alert';
 import axiosInstance from '@/lib/axiosInstance';
@@ -13,7 +13,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { formatDate } from '@/lib/utils';
 
-const page = () => {
+const Page = () => {
   const router = useRouter();
   const { trip } = useTrip();
   const [error, setError] = useState<string | null>(null);
@@ -42,7 +42,7 @@ const page = () => {
         await axiosInstance.put(`/groups/${trip.id}`, values);
         actions.setSubmitting(false);
         router.push('/trips');
-      } catch (err: unknown) {
+      } catch {
         setError('Failed to update the trip.');
         actions.setSubmitting(false);
       }
@@ -93,4 +93,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default Page;

--- a/frontend/app/(root)/trips/[id]/edit/page.tsx
+++ b/frontend/app/(root)/trips/[id]/edit/page.tsx
@@ -1,7 +1,96 @@
-import React from 'react';
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import TripForm from '@/components/trip/TripForm';
+import { Alert } from '@/components/ui/alert';
+import axiosInstance from '@/lib/axiosInstance';
+import { z } from 'zod';
+import { createGroupFormSchema } from '@/validation/groupFormSchemas';
+import { FormikHelpers } from 'formik';
+import { useTrip } from '@/context/TripContext';
+import { Group } from '@/validation/groupSchema';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import { formatDate } from '@/lib/utils';
 
-function page() {
-  return <div>edit trip page</div>;
-}
+const page = () => {
+  const router = useRouter();
+  const { trip } = useTrip();
+  const [error, setError] = useState<string | null>(null);
+
+  const mapTripToInitialValues = (
+    trip: Group,
+  ): z.infer<typeof createGroupFormSchema> => {
+    return {
+      name: trip.name || '',
+      description: trip.description || '',
+      tripStartDate: trip.tripStartDate
+        ? new Date(trip.tripStartDate)
+        : new Date(),
+      tripEndDate: trip.tripEndDate ? new Date(trip.tripEndDate) : new Date(),
+      tags: Array.isArray(trip.tags) ? trip.tags : [],
+      groupImageUrl: trip.groupImageUrl || '',
+    };
+  };
+
+  const handleUpdateTrip = async (
+    values: z.infer<typeof createGroupFormSchema>,
+    actions: FormikHelpers<z.infer<typeof createGroupFormSchema>>,
+  ) => {
+    if (trip) {
+      try {
+        await axiosInstance.put(`/groups/${trip.id}`, values);
+        actions.setSubmitting(false);
+        router.push('/trips');
+      } catch (err: unknown) {
+        setError('Failed to update the trip.');
+        actions.setSubmitting(false);
+      }
+    } else {
+      router.push('/trips');
+    }
+  };
+
+  if (!trip) {
+    return <div>Loading trip data...</div>;
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <Button
+          onClick={() => router.push(`/trips/${trip.id}`)}
+          className="bg-white border text-primary-500 hover:bg-gray-100 shadow-sm  rounded-full mb-4"
+        >
+          <ArrowLeft />
+          <span>Back to Trip Summary</span>
+        </Button>
+
+        <div className="text-md -mt-4 font-semibold text-gray-400">
+          {trip.name}
+          {trip.tripStartDate && trip.tripEndDate && (
+            <>
+              {' | '}
+              {formatDate(trip.tripStartDate)} - {formatDate(trip.tripEndDate)}
+            </>
+          )}
+        </div>
+      </div>
+      <div className="section py-6 px-12 border">
+        <h1 className="text-heading1-bold">Edit Trip</h1>
+        {error && (
+          <Alert variant="destructive" className="my-4 p-4">
+            {error}
+          </Alert>
+        )}
+        <TripForm
+          initialValues={mapTripToInitialValues(trip)}
+          onSubmit={handleUpdateTrip}
+          mode="edit"
+        />
+      </div>
+    </>
+  );
+};
 
 export default page;

--- a/frontend/app/(root)/trips/[id]/page.tsx
+++ b/frontend/app/(root)/trips/[id]/page.tsx
@@ -45,7 +45,6 @@ export default function TripPage() {
       setToFetchGroup(false);
     }
     if (trip && user && user.id) {
-      console.log('getujemy vote');
       setVotes(getVotes(user.id));
     }
   }, [trip, toFetchGroup, refreshTrip, setToFetchGroup]);

--- a/frontend/app/(root)/trips/[id]/page.tsx
+++ b/frontend/app/(root)/trips/[id]/page.tsx
@@ -99,13 +99,20 @@ export default function TripPage() {
     <div>
       <Button
         onClick={() => router.push('/trips')}
-        className="bg-white border text-primary-500 hover:bg-gray-100 shadow-sm rounded-full my-4"
+        className="bg-white border text-primary-500 hover:bg-gray-100 shadow-sm rounded-full mb-4"
       >
         <ArrowLeft />
         <span>Back To Trips</span>
       </Button>
 
-      <TripCard trip={trip} />
+      <TripCard
+        trip={trip}
+        showDropdownOptions={
+          !!trip.memberships.find(
+            (m) => m.userId === user?.id && m.role === 'OWNER',
+          )
+        }
+      />
 
       <button
         onClick={() => redirect(`/trips/${trip.id}/activities/create`)}

--- a/frontend/app/(root)/trips/[id]/page.tsx
+++ b/frontend/app/(root)/trips/[id]/page.tsx
@@ -47,7 +47,7 @@ export default function TripPage() {
     if (trip && user && user.id) {
       setVotes(getVotes(user.id));
     }
-  }, [trip, toFetchGroup, refreshTrip, setToFetchGroup]);
+  }, [trip, toFetchGroup, refreshTrip, setToFetchGroup, getVotes, user]);
 
   if (!trip) return null;
 

--- a/frontend/app/(root)/trips/create/page.tsx
+++ b/frontend/app/(root)/trips/create/page.tsx
@@ -6,8 +6,7 @@ import { createGroupFormSchema } from '@/validation/groupFormSchemas';
 import { useState } from 'react';
 import { FormikHelpers } from 'formik';
 import { z } from 'zod';
-import { getToken } from '@/lib/auth';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 
 const NewTripPage = () => {
   const [error, setError] = useState<string | null>(null);
@@ -17,11 +16,7 @@ const NewTripPage = () => {
     actions: FormikHelpers<z.infer<typeof createGroupFormSchema>>,
   ) => {
     try {
-      const token = getToken();
-      const response = await axios.post('/api/v1/groups', values, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      console.log(response);
+      const response = await axiosInstance.post('groups', values);
       actions.resetForm();
       window.location.href = '/trips';
     } catch (err: unknown) {

--- a/frontend/app/(root)/trips/create/page.tsx
+++ b/frontend/app/(root)/trips/create/page.tsx
@@ -8,6 +8,8 @@ import { FormikHelpers } from 'formik';
 import { z } from 'zod';
 import axiosInstance from '@/lib/axiosInstance';
 import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
 
 const NewTripPage = () => {
   const [error, setError] = useState<string | null>(null);
@@ -26,15 +28,24 @@ const NewTripPage = () => {
   };
 
   return (
-    <div className="section py-6 px-12">
-      <h1 className="text-heading1-bold">Create Trip</h1>
-      {error && (
-        <Alert variant="destructive" className="my-4 p-4">
-          {error}
-        </Alert>
-      )}
-      <TripForm onSubmit={handleCreateTrip} mode="create" />
-    </div>
+    <>
+      <Button
+        onClick={() => router.push(`/trips`)}
+        className="bg-white border text-primary-500 hover:bg-gray-100 shadow-sm  rounded-full mb-4"
+      >
+        <ArrowLeft />
+        <span>Back to Trips</span>
+      </Button>
+      <div className="section py-6 px-12 border">
+        <h1 className="text-heading1-bold">Create Trip</h1>
+        {error && (
+          <Alert variant="destructive" className="my-4 p-4">
+            {error}
+          </Alert>
+        )}
+        <TripForm onSubmit={handleCreateTrip} mode="create" />
+      </div>
+    </>
   );
 };
 

--- a/frontend/app/(root)/trips/create/page.tsx
+++ b/frontend/app/(root)/trips/create/page.tsx
@@ -7,10 +7,11 @@ import { useState } from 'react';
 import { FormikHelpers } from 'formik';
 import { z } from 'zod';
 import axiosInstance from '@/lib/axiosInstance';
+import { useRouter } from 'next/navigation';
 
 const NewTripPage = () => {
   const [error, setError] = useState<string | null>(null);
-
+  const router = useRouter();
   const handleCreateTrip = async (
     values: z.infer<typeof createGroupFormSchema>,
     actions: FormikHelpers<z.infer<typeof createGroupFormSchema>>,
@@ -18,7 +19,7 @@ const NewTripPage = () => {
     try {
       const response = await axiosInstance.post('groups', values);
       actions.resetForm();
-      window.location.href = '/trips';
+      router.push('/trips');
     } catch (err: unknown) {
       setError(err.message || 'An error occurred');
     }

--- a/frontend/app/(root)/trips/create/page.tsx
+++ b/frontend/app/(root)/trips/create/page.tsx
@@ -19,11 +19,11 @@ const NewTripPage = () => {
     actions: FormikHelpers<z.infer<typeof createGroupFormSchema>>,
   ) => {
     try {
-      const response = await axiosInstance.post('groups', values);
+      await axiosInstance.post('groups', values);
       actions.resetForm();
       router.push('/trips');
-    } catch (err: unknown) {
-      setError(err.message || 'An error occurred');
+    } catch {
+      setError('An error occurred');
     }
   };
 

--- a/frontend/app/(root)/trips/page.tsx
+++ b/frontend/app/(root)/trips/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 import React from 'react';
 import TripCard from '@/components/trip/TripCard';
-import { getToken, logout } from '@/lib/auth';
-import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { Group, groupSchema } from '@/validation/groupSchema';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -16,6 +14,7 @@ import {
   ArrowUp,
 } from 'lucide-react';
 import { Alert } from '@/components/ui/alert';
+import axiosInstance from '@/lib/axiosInstance';
 
 function Page() {
   const [error, setError] = useState<string | null>(null);
@@ -33,14 +32,7 @@ function Page() {
   useEffect(() => {
     const fetchTrips = async () => {
       try {
-        const token = getToken();
-        if (!token) {
-          logout();
-          return;
-        }
-
-        const response = await axios.get('/api/v1/groups/user-groups', {
-          headers: { Authorization: `Bearer ${token}` },
+        const response = await axiosInstance.get('groups/user-groups', {
           params: {
             page: page - 1,
             size: tripsPerPage,

--- a/frontend/components/activity/ActivityCard.tsx
+++ b/frontend/components/activity/ActivityCard.tsx
@@ -144,7 +144,7 @@ export default function ActivityCard({
           </Link>
         )}
       </div>
-      <div className="flex flex-col justify-between items-end">
+      <div className="flex flex-col justify-between gap-2 items-end">
         <DropdownMenu>
           <DropdownMenuTrigger className="text-gray-400 rounded-full hover:bg-gray-100 p-1.5 h-min w-min">
             <EllipsisVertical width={20} height={20} />

--- a/frontend/components/activity/ActivityCard.tsx
+++ b/frontend/components/activity/ActivityCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { ActivitySchema } from '@/validation/activitySchema';
+import YesNoModal from '../shared/YesNoModal';
 import {
   EllipsisVertical,
   MapPinIcon,
@@ -159,11 +160,24 @@ export default function ActivityCard({
               <span>Edit</span>
             </DropdownMenuItem>
             <DropdownMenuItem
-              className="cursor-pointer !text-red-800 hover:!bg-red-500/10 flex items-center gap-2"
-              onClick={() => handleDelete()}
+              className="cursor-pointer !text-red-800 hover:!bg-red-500/10"
+              onSelect={(e) => e.preventDefault()}
             >
-              <Trash width={16} height={16} />
-              <span>Delete</span>
+              <div>
+                <YesNoModal
+                  title="Are you sure you want to delete this activity?"
+                  description={`Activity "${activity.name}" will be permanently removed.`}
+                  cancelName="Cancel"
+                  actionName="Delete"
+                  onConfirm={handleDelete}
+                  trigger={
+                    <div className="flex items-center gap-2">
+                      <Trash width={16} height={16} />
+                      <span>Delete</span>
+                    </div>
+                  }
+                />
+              </div>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/frontend/components/activity/ActivityCard.tsx
+++ b/frontend/components/activity/ActivityCard.tsx
@@ -22,9 +22,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 import { useTrip } from '@/context/TripContext';
-import { getToken } from '@/lib/auth';
 import { appStore } from '@/store/appStore';
 import { useEffect, useState } from 'react';
 import { Vote } from '@/validation/voteSchema';
@@ -52,7 +51,6 @@ export default function ActivityCard({
   }, [trip, user?.id, getVotes, user]);
 
   const castVote = async (activityId: number, type: 'FOR' | 'AGAINST') => {
-    const token = getToken();
     const currentActivity = trip?.activities.find((a) => a.id === activityId);
     const existingVote = currentActivity?.votes.find(
       (v: Vote) => v.userId === user?.id,
@@ -60,21 +58,18 @@ export default function ActivityCard({
 
     try {
       if (existingVote && existingVote.voteType === type) {
-        await axios.delete(
-          `/api/v1/groups/${trip!.id}/activities/${activityId}/votes/${existingVote.id}`,
-          { headers: { Authorization: `Bearer ${token}` } },
+        await axiosInstance.delete(
+          `groups/${trip!.id}/activities/${activityId}/votes/${existingVote.id}`,
         );
       } else if (existingVote) {
-        await axios.put(
-          `/api/v1/groups/${trip!.id}/activities/${activityId}/votes/${existingVote.id}`,
+        await axiosInstance.put(
+          `groups/${trip!.id}/activities/${activityId}/votes/${existingVote.id}`,
           { voteType: type },
-          { headers: { Authorization: `Bearer ${token}` } },
         );
       } else {
-        await axios.post(
-          `/api/v1/groups/${trip!.id}/activities/${activityId}/votes`,
+        await axiosInstance.post(
+          `groups/${trip!.id}/activities/${activityId}/votes`,
           { voteType: type },
-          { headers: { Authorization: `Bearer ${token}` } },
         );
       }
 
@@ -87,12 +82,8 @@ export default function ActivityCard({
   const handleDelete = async () => {
     try {
       if (activity && trip) {
-        const token = getToken();
-        await axios.delete(
-          `/api/v1/groups/${trip.id}/activities/${activity.id}`,
-          {
-            headers: { Authorization: `Bearer ${token}` },
-          },
+        await axiosInstance.delete(
+          `groups/${trip.id}/activities/${activity.id}`,
         );
         toast(`Activity ${activity.name} deleted!`, {
           duration: 7000,

--- a/frontend/components/activity/ActivityForm.tsx
+++ b/frontend/components/activity/ActivityForm.tsx
@@ -9,6 +9,7 @@ import { Button } from '../ui/button';
 import { Textarea } from '../ui/textarea';
 import { Group } from '@/validation/groupSchema';
 import { formatDate } from '@/lib/utils';
+import YesNoModal from '../shared/YesNoModal';
 
 type ActivityFormValues = z.infer<typeof activityFormSchema>;
 
@@ -56,7 +57,7 @@ export default function ActivityForm({
           onSubmit(values, actions);
         }}
       >
-        {({ errors, touched }) => (
+        {({ errors, touched, submitForm }) => (
           <Form>
             <div className="mt-4">
               <label className="font-semibold" htmlFor="name">
@@ -148,18 +149,34 @@ export default function ActivityForm({
                 )}
               />
             </div>
-
-            <Button
-              className="bg-primary-600 hover:bg-primary-500 px-5 py-4 mt-4 text-sm"
-              type="submit"
-              disabled={isSubmitting}
-            >
-              {isSubmitting
-                ? 'Submitting...'
-                : initialValues.name
-                  ? 'Save Changes'
-                  : 'Create an Activity'}
-            </Button>
+            {initialValues.name ? (
+              <>
+                <YesNoModal
+                  title="Are you sure you want to edit this activity?"
+                  description=""
+                  cancelName="Cancel"
+                  actionName="Confirm"
+                  onConfirm={submitForm}
+                  trigger={
+                    <Button
+                      className="bg-primary-600 hover:bg-primary-500 px-5 py-4 mt-4 text-sm"
+                      disabled={isSubmitting}
+                      type="button"
+                    >
+                      {isSubmitting ? 'Submitting...' : 'Save Changes'}
+                    </Button>
+                  }
+                />
+              </>
+            ) : (
+              <Button
+                className="bg-primary-600 hover:bg-primary-500 px-5 py-4 mt-4 text-sm"
+                type="submit"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Submitting...' : 'Submit'}
+              </Button>
+            )}
           </Form>
         )}
       </Formik>

--- a/frontend/components/shared/Navbar.tsx
+++ b/frontend/components/shared/Navbar.tsx
@@ -14,7 +14,7 @@ import { Button } from '../ui/button';
 import { Avatar, AvatarFallback } from '../ui/avatar';
 import { Bell, LogOut, Plane, User } from 'lucide-react';
 import { getToken, isLoggedIn, logout } from '@/lib/auth';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 import { appStore } from '@/store/appStore';
 
 function Navbar() {
@@ -31,17 +31,10 @@ function Navbar() {
   );
 
   const fetchNotifications = async () => {
-    const token = getToken();
-    if (!token) return;
-
     try {
       const [friendsRes, groupsRes] = await Promise.all([
-        axios.get('/api/v1/friend-invitations/received', {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
-        axios.get('/api/v1/group-invitations/received', {
-          headers: { Authorization: `Bearer ${token}` },
-        }),
+        axiosInstance.get('friend-invitations/received'),
+        axiosInstance.get('/group-invitations/received'),
       ]);
 
       const count =

--- a/frontend/components/shared/YesNoModal.tsx
+++ b/frontend/components/shared/YesNoModal.tsx
@@ -1,0 +1,57 @@
+'use client';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { X } from 'lucide-react';
+
+export default function YesNoModal({
+  title,
+  description,
+  cancelName = 'Cancel',
+  actionName = 'Confirm',
+  onConfirm,
+  trigger,
+}: {
+  title: string;
+  description: string;
+  cancelName?: string;
+  actionName?: string;
+  onConfirm: () => void;
+  trigger: React.ReactNode;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex justify-between">
+            <AlertDialogTitle>{title}</AlertDialogTitle>
+            <AlertDialogCancel className="group flex items-start bg-transparent border-none p-0 m-0 shadow-none hover:bg-transparent focus:outline-none focus:ring-0 !cursor-pointer">
+              <X className="!text-gray-400 !w-6 !h-6 !transition-colors group-hover:!text-gray-500" />
+            </AlertDialogCancel>
+          </div>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel className="border text-primary-500 border-primary-500 hover:text-light-1 hover:bg-primary-700">
+            {cancelName}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-primary-600 text-light-1 hover:bg-primary-700"
+            onClick={onConfirm}
+          >
+            {actionName}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/components/trip/TripCard.tsx
+++ b/frontend/components/trip/TripCard.tsx
@@ -4,11 +4,23 @@ import Link from 'next/link';
 import { Group } from '@/validation/groupSchema';
 import { useState } from 'react';
 import { formatDate } from '@/lib/utils';
+import { Ellipsis, Pencil, Trash } from 'lucide-react';
+import YesNoModal from '../shared/YesNoModal';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import { useRouter } from 'next/navigation';
+import axiosInstance from '@/lib/axiosInstance';
+import { toast } from 'sonner';
 
 interface TripCardProps {
   trip: Group;
+  showDropdownOptions?: boolean;
 }
-function TripCard({ trip }: TripCardProps) {
+function TripCard({ trip, showDropdownOptions = false }: TripCardProps) {
   const {
     id,
     name,
@@ -22,6 +34,37 @@ function TripCard({ trip }: TripCardProps) {
     groupImageUrl || '/assets/trip-placeholder.png',
   );
 
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    try {
+      if (trip) {
+        await axiosInstance.delete(`groups/${trip.id}`);
+        toast(`Trip ${name} deleted!`, {
+          duration: 7000,
+          action: {
+            label: 'Close',
+            onClick: () => {
+              toast.dismiss();
+            },
+          },
+        });
+
+        router.push('/trips');
+      }
+    } catch {
+      toast(`Error deleting the trip`, {
+        duration: 7000,
+        action: {
+          label: 'Close',
+          onClick: () => {
+            toast.dismiss();
+          },
+        },
+      });
+    }
+  };
+
   return (
     <div className="section p-0 flex flex-col md:flex-row md:items-start justify-start md:justify-between border bg-white shadow-md rounded-lg">
       <div className="py-6 px-6 w-full md:w-2/3">
@@ -30,6 +73,7 @@ function TripCard({ trip }: TripCardProps) {
             {name}
           </h4>
         </Link>
+
         <p className="text-small-regular text-gray-500 mb-2">
           {tripStartDate ? formatDate(tripStartDate) : 'N/A'} -{' '}
           {tripEndDate ? formatDate(tripEndDate) : 'N/A'}
@@ -54,12 +98,47 @@ function TripCard({ trip }: TripCardProps) {
           </button>
         </Link>
       </div>
-      <div className="relative w-48 h-48 md:w-60 md:h-60 hidden md:block overflow-hidden">
+      <div className="relative w-48 h-48 md:w-60 md:h-60 hidden md:block overflow-hidden rounded-r-lg">
+        {showDropdownOptions && (
+          <DropdownMenu>
+            <DropdownMenuTrigger className="absolute top-2 right-2 text-primary-500 border bg-white shadow-md rounded-full hover:bg-gray-100 p-1.5 h-min w-min">
+              <Ellipsis width={20} height={20} />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem
+                onClick={() => router.push(`/trips/${id}/edit`)}
+                className="cursor-pointer !text-primary-500 hover:!bg-primary-500/10 flex items-center gap-2"
+              >
+                <Pencil width={16} height={16} />
+                <span>Edit</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="cursor-pointer !text-red-800 hover:!bg-red-500/10"
+                onSelect={(e) => e.preventDefault()}
+              >
+                <YesNoModal
+                  title="Are you sure you want to delete this activity?"
+                  description={`Group "${name}" will be permanently removed.`}
+                  cancelName="Cancel"
+                  actionName="Delete"
+                  onConfirm={handleDelete}
+                  trigger={
+                    <div className="flex items-center gap-2">
+                      <Trash width={16} height={16} />
+                      <span>Delete</span>
+                    </div>
+                  }
+                />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
         <Link href={`/trips/${id}`}>
           <img
             src={imageSrc}
             alt={name}
-            className="w-full h-full object-cover rounded-r-lg"
+            className="w-full h-full object-cover"
             onError={() => setImageSrc('/assets/trip-placeholder.png')}
           />
         </Link>

--- a/frontend/components/ui/alert-dialog.tsx
+++ b/frontend/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/components/ui/alert-dialog.tsx
+++ b/frontend/components/ui/alert-dialog.tsx
@@ -1,16 +1,16 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
 
-const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialog = AlertDialogPrimitive.Root;
 
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = AlertDialogPrimitive.Portal
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -18,14 +18,14 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
     )}
     {...props}
     ref={ref}
   />
-))
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
@@ -36,14 +36,14 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
       )}
       {...props}
     />
   </AlertDialogPortal>
-))
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({
   className,
@@ -51,13 +51,13 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
-      className
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className,
     )}
     {...props}
   />
-)
-AlertDialogHeader.displayName = "AlertDialogHeader"
+);
+AlertDialogHeader.displayName = 'AlertDialogHeader';
 
 const AlertDialogFooter = ({
   className,
@@ -65,13 +65,13 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
     )}
     {...props}
   />
-)
-AlertDialogFooter.displayName = "AlertDialogFooter"
+);
+AlertDialogFooter.displayName = 'AlertDialogFooter';
 
 const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
@@ -79,11 +79,11 @@ const AlertDialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold", className)}
+    className={cn('text-lg font-semibold', className)}
     {...props}
   />
-))
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
@@ -91,12 +91,12 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
+));
 AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName
+  AlertDialogPrimitive.Description.displayName;
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
@@ -107,8 +107,8 @@ const AlertDialogAction = React.forwardRef<
     className={cn(buttonVariants(), className)}
     {...props}
   />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
@@ -117,14 +117,14 @@ const AlertDialogCancel = React.forwardRef<
   <AlertDialogPrimitive.Cancel
     ref={ref}
     className={cn(
-      buttonVariants({ variant: "outline" }),
-      "mt-2 sm:mt-0",
-      className
+      buttonVariants({ variant: 'outline' }),
+      'mt-2 sm:mt-0',
+      className,
     )}
     {...props}
   />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
@@ -138,4 +138,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+};

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,56 +1,56 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : 'button';
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Button.displayName = "Button"
+    );
+  },
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,56 +1,56 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from '@/lib/utils';
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: 'bg-primary-500 text-light-1 shadow hover:bg-primary-500/90',
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
-        icon: 'h-9 w-9',
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: "default",
+      size: "default",
     },
-  },
-);
+  }
+)
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+  asChild?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
+    const Comp = asChild ? Slot : "button"
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    );
-  },
-);
-Button.displayName = 'Button';
+    )
+  }
+)
+Button.displayName = "Button"
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,18 +1,18 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -21,13 +21,13 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -38,8 +38,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
       )}
       {...props}
     >
@@ -50,8 +50,8 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({
   className,
@@ -59,13 +59,13 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className,
     )}
     {...props}
   />
-)
-DialogHeader.displayName = "DialogHeader"
+);
+DialogHeader.displayName = 'DialogHeader';
 
 const DialogFooter = ({
   className,
@@ -73,13 +73,13 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
     )}
     {...props}
   />
-)
-DialogFooter.displayName = "DialogFooter"
+);
+DialogFooter.displayName = 'DialogFooter';
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -88,13 +88,13 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
     )}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -102,11 +102,11 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -119,4 +119,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};

--- a/frontend/context/TripContext.tsx
+++ b/frontend/context/TripContext.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   ReactNode,
 } from 'react';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 import { useParams } from 'next/navigation';
 import { getToken, decodeToken } from '@/lib/auth';
 import { Group, groupSchema } from '@/validation/groupSchema';
@@ -44,9 +44,7 @@ export function TripContextProvider({ children }: { children: ReactNode }) {
       const token = getToken();
       const userId = token ? decodeToken(token)?.sub : '';
 
-      const response = await axios.get(`/api/v1/groups/${params.id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const response = await axiosInstance.get(`groups/${params.id}`);
 
       const fetchedTrip = groupSchema.parse(response.data);
 

--- a/frontend/lib/axiosInstance.ts
+++ b/frontend/lib/axiosInstance.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { getToken } from './auth';
+
+const axiosInstance = axios.create({
+  baseURL: '/api/v1/',
+  timeout: 1000,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+axiosInstance.interceptors.request.use(
+  function (config) {
+    const token = getToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  function (error) {
+    return Promise.reject(error);
+  },
+);
+
+export default axiosInstance;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
+        source: '/auth/:path*',
+        destination: 'http://localhost:8080/auth/:path*',
+      },
+      {
         source: '/api/:path*',
         destination: 'http://localhost:8080/api/:path*',
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-avatar": "^1.1.2",
+        "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-select": "^2.2.4",
@@ -1787,6 +1788,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.13.tgz",
+      "integrity": "sha512-ARFmqUyhIVS3+riWzwGTe7JLjqwqgnODBUZdqpWar/z1WFs9z76fuOs/2BOWCR+YboRn4/WN9aoaGVwqNRr8VA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.9",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.6",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.8",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-slot": "1.2.2",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@radix-ui/react-alert-dialog": "^1.1.13",
         "@radix-ui/react-avatar": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
@@ -1685,6 +1686,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.13.tgz",
+      "integrity": "sha512-/uPs78OwxGxslYOG5TKeUsv9fZC0vo376cXSADdKirTmsLJU2au6L3n34c3p6W26rFDDDze/hwy4fYeNd0qdGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.13",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-slot": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@radix-ui/react-alert-dialog": "^1.1.13",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-dropdown-menu": "^2.1.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-avatar": "^1.1.2",
+    "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.6",
     "@radix-ui/react-select": "^2.2.4",

--- a/frontend/providers/WebSocketProvider.tsx
+++ b/frontend/providers/WebSocketProvider.tsx
@@ -29,16 +29,15 @@ export const WebSocketProvider = ({
     const fetchUserData = async () => {
       if (!user) {
         try {
-          const response = await axiosInstance.get('users');
-          const userData = response.data;
-          console.log(userData);
+          const userResponse = await axiosInstance.get('users');
+          const userData = userResponse.data;
           setUser(userData);
 
-          const response2 = await axios.get('/api/v1/friend-invitations/sent', {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          const lala = response2.data;
-          lala.forEach((invitation) => {
+          const invitationsResponse = await axiosInstance.get(
+            'friend-invitations/sent',
+          );
+          const invitationsData = invitationsResponse.data;
+          invitationsData.forEach((invitation) => {
             console.log(invitation.receiverId);
             addSentFriendInvitation(invitation.receiverId);
           });

--- a/frontend/providers/WebSocketProvider.tsx
+++ b/frontend/providers/WebSocketProvider.tsx
@@ -4,7 +4,7 @@ import { appStore } from '@/store/appStore';
 import { getToken } from '@/lib/auth';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
-import axios from 'axios';
+import axiosInstance from '@/lib/axiosInstance';
 import { toast } from 'sonner';
 import { MembershipSchema } from '@/validation/membershipSchema';
 
@@ -25,9 +25,7 @@ export const WebSocketProvider = ({
     const fetchUserData = async () => {
       if (!user) {
         try {
-          const response = await axios.get('/api/v1/users', {
-            headers: { Authorization: `Bearer ${token}` },
-          });
+          const response = await axiosInstance.get('users');
           const userData = response.data;
           setUser(userData);
         } catch (err) {


### PR DESCRIPTION
Nie działa usuwanie grupy, jeśli zostało wysłane do niej jakieś zaproszenie. Wyskakuje 403 forbidden.
![image](https://github.com/user-attachments/assets/afa86cf0-5bb6-4325-aa5d-dc6c47fd35fa)

## Summary by Sourcery

Unify API calls through a shared axiosInstance and enhance user interactions with confirmation modals and toast feedback across invitations, trips, and activities, while adding full trip edit support and improving UI consistency.

New Features:
- Introduce a shared axiosInstance with automatic auth token injection for all API requests
- Implement a reusable YesNoModal component for confirmation dialogs
- Add Radix-based alert-dialog and dialog UI primitives to support modal interactions
- Integrate confirmation modals on invitations page for accept/reject actions with toast feedback
- Add dropdown menu options on TripCard for owners to edit or delete trips with confirmation
- Create full edit trip page with TripForm, pre-filled values, and update functionality
- Enhance trip and activity cards with deletion via modal confirmation and toast notifications

Enhancements:
- Replace manual getToken header management with centralized axiosInstance across the frontend
- Standardize API endpoint paths and remove hardcoded base URLs in axios calls
- Add toast notifications for loading, success, and error states on async actions
- Refactor Button component variants and sizes for consistent styling
- Introduce back navigation buttons with arrow icons on trip create, edit, and detail pages
- Add Next.js rewrites for auth and API routes in next.config.ts

Build:
- Add @radix-ui/react-dialog and @radix-ui/react-alert-dialog dependencies for modal support

Chores:
- Remove obsolete getToken imports and direct Axios header configurations
- Update dependencies and clean up redundant code paths